### PR TITLE
Fix search result images breaking out of container. Fix #44

### DIFF
--- a/_sass/_screen.scss
+++ b/_sass/_screen.scss
@@ -1429,6 +1429,10 @@ nav ul {
     clear: both;
 }
 
+.search-result img {
+    max-width: 100%;
+}
+
 /* @end */
 
 /* @group ----- Items/Browse ----- */

--- a/css/style.css
+++ b/css/style.css
@@ -1494,6 +1494,10 @@
     clear: both;
   }
 
+  .search-result img {
+    max-width: 100%;
+  }
+
   /* @end */
   /* @group ----- Items/Browse ----- */
   #no-results {


### PR DESCRIPTION
This is a small fix to address #44, where the images in search results aren't respecting the link container width.